### PR TITLE
Fix some dangling SH-RPi references

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -46,10 +46,10 @@ params:
     feedback:
       enable: false
       yes: Glad to hear it! Please <a
-        href="https://github.com/hatlabs/sh-rpi/issues/new">tell us how we can
+        href="https://github.com/hatlabs/halmet/issues/new">tell us how we can
         improve</a>.
       no: Sorry to hear that. Please <a
-        href="https://github.com/hatlabs/sh-rpi/issues/new">tell us how we can
+        href="https://github.com/hatlabs/halmet/issues/new">tell us how we can
         improve</a>.
     readingtime:
       enable: false

--- a/content/en/docs/hardware/_index.md
+++ b/content/en/docs/hardware/_index.md
@@ -78,14 +78,14 @@ meaning that they do not share a common ground with the rest of the board.
   <div class="col-sm-6">
 
 {{< imgrel "HALMET-conx-top.jpg" "100%" >}}
-SH-RPi connectors, top side.
+HALMET connectors, top side.
 {{< /imgrel >}}
 
    </div>
    <div class="col-sm-6">
 
 {{< imgrel "HALMET-conx-bottom.jpg" "100%" >}}
-SH-RPi connectors, bottom side.
+HALMET connectors, bottom side.
 {{< /imgrel >}}
 
    </div>


### PR DESCRIPTION
Some SH-RPi references were left behind when the template was copied over. Fixed now.
